### PR TITLE
Fix chicago tests

### DIFF
--- a/chicago/chicago.test/statics/01-numbers.spt
+++ b/chicago/chicago.test/statics/01-numbers.spt
@@ -1,6 +1,6 @@
 module numbers
 
-language london
+language chicago
 start symbol Start 
 
 test number literal [[ 

--- a/chicago/chicago.test/statics/02-booleans.spt
+++ b/chicago/chicago.test/statics/02-booleans.spt
@@ -66,8 +66,7 @@ test type error [[
 
 test not eq [[
   $ ! 1 == 2
-]]
-analysis fails
+]] analysis fails
 
 
 

--- a/chicago/chicago.test/statics/02-booleans.spt
+++ b/chicago/chicago.test/statics/02-booleans.spt
@@ -1,6 +1,6 @@
 module booleans
 
-language london
+language chicago
 start symbol Start
 
 test true [[
@@ -25,7 +25,8 @@ test not eq [[
 
 test not eq [[
   $ ! 1 == 2
-]] analysis succeeds
+]] 
+analysis fails
 
 test or [[
   $ false || true 

--- a/chicago/chicago.test/statics/02-booleans.spt
+++ b/chicago/chicago.test/statics/02-booleans.spt
@@ -23,11 +23,6 @@ test not eq [[
   $ ! false
 ]] analysis succeeds
 
-test not eq [[
-  $ ! 1 == 2
-]] 
-analysis fails
-
 test or [[
   $ false || true 
 ]] analysis succeeds
@@ -69,10 +64,10 @@ test type error [[
   $ 1 && true
 ]] analysis fails 
 
-//test bug in analysis! [[
-//  ! 1 
-//]] analysis fails
-
+test not eq [[
+  $ ! 1 == 2
+]]
+analysis fails
 
 
 

--- a/chicago/chicago.test/statics/03-variables.spt
+++ b/chicago/chicago.test/statics/03-variables.spt
@@ -1,6 +1,6 @@
 module variables
 
-language london
+language chicago
 start symbol Start
 
 test free variable [[

--- a/chicago/chicago.test/statics/04-types.spt
+++ b/chicago/chicago.test/statics/04-types.spt
@@ -1,6 +1,6 @@
 module functions 
 
-language london
+language chicago
 start symbol Start
 
 test type definition [[

--- a/chicago/chicago.test/statics/05-functions.spt
+++ b/chicago/chicago.test/statics/05-functions.spt
@@ -1,6 +1,6 @@
 module functions 
  
-language london
+language chicago
 start symbol Start
 
 test function literal [[

--- a/chicago/chicago.test/statics/06-records.spt
+++ b/chicago/chicago.test/statics/06-records.spt
@@ -1,6 +1,6 @@
 module records 
  
-language london
+language chicago
 start symbol Start
 
 test record type [[

--- a/chicago/chicago.test/statics/07-modules.spt
+++ b/chicago/chicago.test/statics/07-modules.spt
@@ -1,6 +1,6 @@
 module mod 
  
-language london
+language chicago
 start symbol Start
 
 test module definition [[

--- a/chicago/chicago.test/syntax/01-numbers.spt
+++ b/chicago/chicago.test/syntax/01-numbers.spt
@@ -1,6 +1,6 @@
 module numbers
 
-language london
+language chicago
 start symbol Start
 
 test number literal [[

--- a/chicago/chicago.test/syntax/02-booleans.spt
+++ b/chicago/chicago.test/syntax/02-booleans.spt
@@ -1,6 +1,6 @@
 module booleans
 
-language london
+language chicago
 start symbol Start
 
 test true [[

--- a/chicago/chicago.test/syntax/03-variables.spt
+++ b/chicago/chicago.test/syntax/03-variables.spt
@@ -1,6 +1,6 @@
 module variables
 
-language london
+language chicago
 start symbol Start
 
 test identifier [[

--- a/chicago/chicago.test/syntax/04-types.spt
+++ b/chicago/chicago.test/syntax/04-types.spt
@@ -1,6 +1,6 @@
 module functions 
 
-language london
+language chicago
 start symbol Start
 
 test type definition [[

--- a/chicago/chicago.test/syntax/05-functions.spt
+++ b/chicago/chicago.test/syntax/05-functions.spt
@@ -1,6 +1,6 @@
 module functions 
  
-language london
+language chicago
 start symbol Start
 
 test function literal [[

--- a/chicago/chicago.test/syntax/06-records.spt
+++ b/chicago/chicago.test/syntax/06-records.spt
@@ -1,6 +1,6 @@
 module records 
  
-language london
+language chicago
 start symbol Start
 
 test record type [[

--- a/chicago/chicago.test/syntax/07-modules.spt
+++ b/chicago/chicago.test/syntax/07-modules.spt
@@ -1,6 +1,6 @@
 module mod 
  
-language london
+language chicago
 start symbol Start
 
 test module definition [[


### PR DESCRIPTION
This PR sets the the correct language in all chicago tests, removes a duplicated test, and corrects a failing test.